### PR TITLE
Correct problems with the sed command in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ defaults: &defaults
           command: | 
             cd $AUTH0_CFG
             mv .env.example .env
-            sed -i 's/{DOMAIN}/'$auth0_domain'/g' .env
-            sed -i 's/{API_IDENTIFIER}/'$api_identifier'/g' .env
+            sed -i 's|{DOMAIN}|'$auth0_domain'|g' .env
+            sed -i 's|{API_IDENTIFIER}|'$api_identifier'|g' .env
       - run:
           name: Background Server
           command: cd $AUTH0_CFG && sh exec.sh


### PR DESCRIPTION
Replaced separators inside "sed" command syntax so we can pass an API identifier that contains slashes and replace it in the environment variables file.