### PR TITLE
Swap catches in Laravel middlewares

### DIFF
--- a/01-Authorization-RS256/app/Http/Middleware/CheckJWT.php
+++ b/01-Authorization-RS256/app/Http/Middleware/CheckJWT.php
@@ -42,9 +42,9 @@ class CheckJWT
 
             \Auth::login($user);
 
-        } catch (CoreException $e) {
-            return response()->json(["message" => $e->getMessage()], 401);
         } catch (InvalidTokenException $e) {
+            return response()->json(["message" => $e->getMessage()], 401);
+        } catch (CoreException $e) {
             return response()->json(["message" => $e->getMessage()], 401);
         }
 

--- a/01-Authorization-RS256/app/Http/Middleware/CheckScope.php
+++ b/01-Authorization-RS256/app/Http/Middleware/CheckScope.php
@@ -55,9 +55,9 @@ class CheckScope
 
                 \Auth::login($user);
             }
-        } catch (CoreException $e) {
-            return response()->json(["message" => $e->getMessage()], 401);
         } catch (InvalidTokenException $e) {
+            return response()->json(["message" => $e->getMessage()], 401);
+        } catch (CoreException $e) {
             return response()->json(["message" => $e->getMessage()], 401);
         }
 


### PR DESCRIPTION
As `Auth0\SDK\Exception\InvalidTokenException` extends `Auth0\SDK\Exception\CoreException`, currently the `catch (InvalidTokenException $e)` block will never be reached because all `InvalidTokenException`s will be caught in the `catch (CoreException $e)` block instead.

Swapping them around allows handling `InvalidTokenException` separately from all other `CoreException`s.

Edit: Accompanying PR for the docs is auth0/docs#6805.